### PR TITLE
ask player dominion name when two points selected;fix PlayerInteractEvent called twice when right clicking a block

### DIFF
--- a/core/src/main/java/cn/lunadeer/dominion/handler/SelectPointEventsHandler.java
+++ b/core/src/main/java/cn/lunadeer/dominion/handler/SelectPointEventsHandler.java
@@ -52,9 +52,8 @@ public class SelectPointEventsHandler implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void selectPoint(PlayerInteractEvent event) {
         Player player = event.getPlayer();
-        ItemStack item = player.getInventory().getItemInMainHand();
-
-        if (item.getType() != Material.matchMaterial(Configuration.selectTool)) {
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() != Material.matchMaterial(Configuration.selectTool)) {
             return;
         }
         Block block = event.getClickedBlock();

--- a/languages/zh_cn.yml
+++ b/languages/zh_cn.yml
@@ -130,6 +130,8 @@ select-point-events-handler-text:
   no-dominion: 坐标 {0}, {1}, {2} 位置没有找到领地
   found-dominion: 坐标 {0}, {1}, {2} 所处的领地：{3}
   owner: 领地所有人：{0}
+  ask-player-for-dominion-name: 请输入领地名称（输入cancel取消，亦可重新选择位置）：
+  dominion-creation-canceled: 领地创建已取消
 administrator-command-text:
   reload-cache-button: 重载缓存
   reload-cache-description: 重新加载并构建数据缓存（不要频繁执行）


### PR DESCRIPTION
1. 新增功能：当玩家选择完两个点时，自动询问玩家领地名称（输入cancel取消创建领地），也可以直接重新选择两个点
2. 修复bug：玩家手持物品右键方块时会触发两次PlayerInteractEvent
<img width="479" height="218" alt="92d03d8381f8ef94a2eaaa6f5738a5f6" src="https://github.com/user-attachments/assets/8cbf9b57-44bc-4c76-a031-e7e384378175" />
