### PR TITLE
fix: 修复 1.21.11 没有被正确支持的问题

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
     implementation(project(path = ":versions:v1_21_6", configuration = "reobf"))
     implementation(project(path = ":versions:v1_21_8", configuration = "reobf"))
     implementation(project(path = ":versions:v1_21_9", configuration = "reobf"))
+    implementation(project(path = ":versions:v1_21_11", configuration = "reobf"))
     // Minecraft 26.x no longer supports Spigot runtime mappings.
     implementation(project(path = ":versions:v26", configuration = "shadowRuntimeElements"))
     implementation(project(path = ":versions:v26_2", configuration = "shadowRuntimeElements"))

--- a/core/src/main/java/cn/lunadeer/dominion/utils/XVersionManager.java
+++ b/core/src/main/java/cn/lunadeer/dominion/utils/XVersionManager.java
@@ -16,9 +16,11 @@ public class XVersionManager {
             return ImplementationVersion.v26;
         }
         if (version.contains("1.21")) {
+            if (version.contains("1.21.11")) {
+                return ImplementationVersion.v1_21_11;
+            }
             if (version.contains("1.21.9")
-                    || version.contains("1.21.10")
-                    || version.contains("1.21.11")) {
+                    || version.contains("1.21.10")) {
                 return ImplementationVersion.v1_21_9;
             }
             if (version.contains("1.21.8")) {
@@ -67,6 +69,7 @@ public class XVersionManager {
     public enum ImplementationVersion {
         v26_2,
         v26,
+        v1_21_11,
         v1_21_9,
         v1_21_8,
         v1_21_6,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ include(
     "versions:v1_21_6",
     "versions:v1_21_8",
     "versions:v1_21_9",
+    "versions:v1_21_11",
     "versions:v26",
     "versions:v26_2"
 )

--- a/versions/v1_21_11/build.gradle.kts
+++ b/versions/v1_21_11/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("java")
+    id("io.papermc.paperweight.userdev")
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+}
+
+// utf-8
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}
+
+dependencies {
+    compileOnly(project(":api"))
+    compileOnly(project(":core"))
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    compileOnly("net.kyori:adventure-text-serializer-ansi:4.26.1")
+    paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT")
+    testImplementation(project(":core"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/FakeEntityFactoryImpl.java
+++ b/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/FakeEntityFactoryImpl.java
@@ -1,0 +1,32 @@
+package cn.lunadeer.dominion.v1_21_11.nms;
+
+import cn.lunadeer.dominion.nms.EntityIdAllocator;
+import cn.lunadeer.dominion.nms.FakeEntity;
+import cn.lunadeer.dominion.nms.FakeEntityFactory;
+import net.minecraft.world.entity.Entity;
+import org.bukkit.Location;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Fake entity factory implementation for Minecraft 1.21.11.
+ */
+public class FakeEntityFactoryImpl implements FakeEntityFactory {
+
+    @Override
+    public FakeEntity createBlockDisplay(Location location, BlockData blockData) {
+        int entityId = nextEntityId();
+        return new FakeEntityImpl(entityId, location, FakeEntity.DisplayType.BLOCK_DISPLAY, blockData, null);
+    }
+
+    @Override
+    public FakeEntity createItemDisplay(Location location, ItemStack itemStack) {
+        int entityId = nextEntityId();
+        return new FakeEntityImpl(entityId, location, FakeEntity.DisplayType.ITEM_DISPLAY, null, itemStack);
+    }
+
+    @Override
+    public int nextEntityId() {
+        return EntityIdAllocator.nextEntityId(Entity.class);
+    }
+}

--- a/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/FakeEntityImpl.java
+++ b/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/FakeEntityImpl.java
@@ -1,0 +1,406 @@
+package cn.lunadeer.dominion.v1_21_11.nms;
+
+import cn.lunadeer.dominion.nms.FakeEntity;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Display;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import java.util.*;
+
+/**
+ * Fake entity implementation for Minecraft 1.21.11.
+ * <p>
+ * Same metadata indices as 1.21, but uses PositionMoveRotation-based teleport packet.
+ */
+@SuppressWarnings("unchecked")
+public class FakeEntityImpl implements FakeEntity {
+
+    // ==================== Metadata Accessors (resolved from Display class via reflection) ====================
+    // We avoid direct EntityDataSerializers field references because they may differ across
+    // server forks (e.g., DeerFolia adds CopperGolemState serializer, shifting field mappings).
+    // Instead, we reflectively extract Display's own EntityDataAccessor fields and match by index.
+
+    private static final EntityDataAccessor<Byte> DATA_SHARED_FLAGS_ID;
+    private static final EntityDataAccessor<Integer> INTERPOLATION_START;
+    private static final EntityDataAccessor<Integer> INTERPOLATION_DURATION;
+    private static final EntityDataAccessor<Integer> POS_ROT_INTERPOLATION_DURATION;
+    private static final EntityDataAccessor<Vector3f> TRANSLATION;
+    private static final EntityDataAccessor<Vector3f> SCALE;
+    private static final EntityDataAccessor<Quaternionf> LEFT_ROTATION;
+    private static final EntityDataAccessor<Quaternionf> RIGHT_ROTATION;
+    private static final EntityDataAccessor<Byte> BILLBOARD;
+    private static final EntityDataAccessor<Integer> BRIGHTNESS;
+    private static final EntityDataAccessor<Float> VIEW_RANGE;
+    private static final EntityDataAccessor<Float> SHADOW_RADIUS;
+    private static final EntityDataAccessor<Float> SHADOW_STRENGTH;
+    private static final EntityDataAccessor<Float> WIDTH;
+    private static final EntityDataAccessor<Float> HEIGHT;
+    private static final EntityDataAccessor<Integer> GLOW_COLOR;
+    private static final EntityDataAccessor<BlockState> BLOCK_STATE_ACCESSOR;
+    private static final EntityDataAccessor<net.minecraft.world.item.ItemStack> ITEM_STACK_ACCESSOR;
+    private static final EntityDataAccessor<Byte> ITEM_TRANSFORM;
+
+    static {
+        Map<Integer, EntityDataAccessor<?>> ea = resolveAccessors(net.minecraft.world.entity.Entity.class);
+        Map<Integer, EntityDataAccessor<?>> da = resolveAccessors(Display.class);
+        Map<Integer, EntityDataAccessor<?>> bda = resolveAccessors(Display.BlockDisplay.class);
+        Map<Integer, EntityDataAccessor<?>> ida = resolveAccessors(Display.ItemDisplay.class);
+
+        DATA_SHARED_FLAGS_ID = (EntityDataAccessor<Byte>) ea.get(0);
+        INTERPOLATION_START = (EntityDataAccessor<Integer>) da.get(8);
+        INTERPOLATION_DURATION = (EntityDataAccessor<Integer>) da.get(9);
+        POS_ROT_INTERPOLATION_DURATION = (EntityDataAccessor<Integer>) da.get(10);
+        TRANSLATION = (EntityDataAccessor<Vector3f>) da.get(11);
+        SCALE = (EntityDataAccessor<Vector3f>) da.get(12);
+        LEFT_ROTATION = (EntityDataAccessor<Quaternionf>) da.get(13);
+        RIGHT_ROTATION = (EntityDataAccessor<Quaternionf>) da.get(14);
+        BILLBOARD = (EntityDataAccessor<Byte>) da.get(15);
+        BRIGHTNESS = (EntityDataAccessor<Integer>) da.get(16);
+        VIEW_RANGE = (EntityDataAccessor<Float>) da.get(17);
+        SHADOW_RADIUS = (EntityDataAccessor<Float>) da.get(18);
+        SHADOW_STRENGTH = (EntityDataAccessor<Float>) da.get(19);
+        WIDTH = (EntityDataAccessor<Float>) da.get(20);
+        HEIGHT = (EntityDataAccessor<Float>) da.get(21);
+        GLOW_COLOR = (EntityDataAccessor<Integer>) da.get(22);
+        BLOCK_STATE_ACCESSOR = (EntityDataAccessor<BlockState>) bda.get(23);
+        ITEM_STACK_ACCESSOR = (EntityDataAccessor<net.minecraft.world.item.ItemStack>) ida.get(23);
+        ITEM_TRANSFORM = (EntityDataAccessor<Byte>) ida.get(24);
+    }
+
+    private static Map<Integer, EntityDataAccessor<?>> resolveAccessors(Class<?> clazz) {
+        Map<Integer, EntityDataAccessor<?>> map = new java.util.HashMap<>();
+        for (java.lang.reflect.Field field : clazz.getDeclaredFields()) {
+            if (java.lang.reflect.Modifier.isStatic(field.getModifiers()) &&
+                    EntityDataAccessor.class.isAssignableFrom(field.getType())) {
+                field.setAccessible(true);
+                try {
+                    EntityDataAccessor<?> accessor = (EntityDataAccessor<?>) field.get(null);
+                    map.put(accessor.id(), accessor);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("Failed to access Display metadata field: " + field.getName(), e);
+                }
+            }
+        }
+        return map;
+    }
+
+    // ==================== Instance Fields ====================
+
+    private final int entityId;
+    private final UUID uuid;
+    private final DisplayType displayType;
+    private Location location;
+
+    // Display common properties
+    private int interpolationDelay = 0;
+    private int interpolationDuration = 0;
+    private int posRotInterpolationDuration = 0;
+    private Vector3f translation = new Vector3f(0, 0, 0);
+    private Vector3f scale = new Vector3f(1, 1, 1);
+    private Quaternionf leftRotation = new Quaternionf(0, 0, 0, 1);
+    private Quaternionf rightRotation = new Quaternionf(0, 0, 0, 1);
+    private byte billboard = 0;
+    private int brightness = -1;
+    private float viewRange = 1.0f;
+    private float shadowRadius = 0.0f;
+    private float shadowStrength = 1.0f;
+    private float width = 0.0f;
+    private float height = 0.0f;
+    private int glowColorOverride = -1;
+    private byte entityFlags = 0;
+
+    // BlockDisplay specific
+    private BlockState blockState;
+
+    // ItemDisplay specific
+    private net.minecraft.world.item.ItemStack nmsItemStack;
+    private byte itemTransform = 0;
+
+    FakeEntityImpl(int entityId, Location location, DisplayType displayType,
+                   BlockData blockData, ItemStack itemStack) {
+        this.entityId = entityId;
+        this.uuid = UUID.randomUUID();
+        this.displayType = displayType;
+        this.location = location.clone();
+
+        if (displayType == DisplayType.BLOCK_DISPLAY && blockData != null) {
+            this.blockState = toNmsBlockState(blockData);
+        }
+        if (displayType == DisplayType.ITEM_DISPLAY && itemStack != null) {
+            this.nmsItemStack = toNmsItemStack(itemStack);
+        }
+    }
+
+    @Override
+    public int getEntityId() {
+        return entityId;
+    }
+
+    @Override
+    public DisplayType getDisplayType() {
+        return displayType;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void spawn(Collection<? extends Player> players) {
+        List<Packet<?>> packets = createSpawnPackets();
+        ClientboundBundlePacket bundle = new ClientboundBundlePacket((Iterable) packets);
+        for (Player player : players) {
+            sendPacket(player, bundle);
+        }
+    }
+
+    @Override
+    public void spawn(Player player) {
+        spawn(Collections.singleton(player));
+    }
+
+    @Override
+    public void destroy(Collection<? extends Player> players) {
+        ClientboundRemoveEntitiesPacket packet = new ClientboundRemoveEntitiesPacket(entityId);
+        for (Player player : players) {
+            sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void destroy(Player player) {
+        destroy(Collections.singleton(player));
+    }
+
+    @Override
+    public void teleport(Location location, Collection<? extends Player> players) {
+        this.location = location.clone();
+        ClientboundTeleportEntityPacket packet = createTeleportPacket();
+        for (Player player : players) {
+            sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void teleport(Location location, Player player) {
+        teleport(location, Collections.singleton(player));
+    }
+
+    @Override
+    public void setTranslation(Vector3f translation) {
+        this.translation = new Vector3f(translation);
+    }
+
+    @Override
+    public void setScale(Vector3f scale) {
+        this.scale = new Vector3f(scale);
+    }
+
+    @Override
+    public void setLeftRotation(Quaternionf rotation) {
+        this.leftRotation = new Quaternionf(rotation);
+    }
+
+    @Override
+    public void setRightRotation(Quaternionf rotation) {
+        this.rightRotation = new Quaternionf(rotation);
+    }
+
+    @Override
+    public void setBillboard(byte mode) {
+        this.billboard = mode;
+    }
+
+    @Override
+    public void setBrightness(int blockLight, int skyLight) {
+        this.brightness = blockLight << 4 | skyLight << 20;
+    }
+
+    @Override
+    public void setViewRange(float range) {
+        this.viewRange = range;
+    }
+
+    @Override
+    public void setShadow(float radius, float strength) {
+        this.shadowRadius = radius;
+        this.shadowStrength = strength;
+    }
+
+    @Override
+    public void setGlowColor(Color color) {
+        if (color == null) {
+            this.glowColorOverride = -1;
+            this.entityFlags = (byte) (this.entityFlags & ~0x40); // Clear glow flag (bit 6)
+        } else {
+            this.glowColorOverride = color.asARGB();
+            this.entityFlags = (byte) (this.entityFlags | 0x40); // Set glow flag (bit 6)
+        }
+    }
+
+    @Override
+    public void setInterpolationDuration(int ticks) {
+        this.interpolationDuration = ticks;
+    }
+
+    @Override
+    public void setInterpolationDelay(int ticks) {
+        this.interpolationDelay = ticks;
+    }
+
+    @Override
+    public void setBlockData(BlockData blockData) {
+        if (displayType != DisplayType.BLOCK_DISPLAY) return;
+        this.blockState = toNmsBlockState(blockData);
+    }
+
+    @Override
+    public void setItemStack(ItemStack itemStack) {
+        if (displayType != DisplayType.ITEM_DISPLAY) return;
+        this.nmsItemStack = toNmsItemStack(itemStack);
+    }
+
+    @Override
+    public void setItemTransform(byte transform) {
+        if (displayType != DisplayType.ITEM_DISPLAY) return;
+        this.itemTransform = transform;
+    }
+
+    @Override
+    public void sendMetadata(Collection<? extends Player> players) {
+        ClientboundSetEntityDataPacket packet = createMetadataPacket();
+        for (Player player : players) {
+            sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void sendMetadata(Player player) {
+        sendMetadata(Collections.singleton(player));
+    }
+
+    @Override
+    public Location getLocation() {
+        return location.clone();
+    }
+
+    // ==================== Internal Helpers ====================
+
+    private void sendPacket(Player player, Packet<?> packet) {
+        getServerPlayer(player).connection.send(packet);
+    }
+
+    private List<Packet<?>> createSpawnPackets() {
+        List<Packet<?>> packets = new ArrayList<>();
+
+        EntityType<?> entityType = displayType == DisplayType.BLOCK_DISPLAY
+                ? EntityType.BLOCK_DISPLAY
+                : EntityType.ITEM_DISPLAY;
+
+        ClientboundAddEntityPacket spawnPacket = new ClientboundAddEntityPacket(
+                entityId, uuid,
+                location.getX(), location.getY(), location.getZ(),
+                0f, 0f,
+                entityType,
+                0,
+                Vec3.ZERO,
+                0.0
+        );
+        packets.add(spawnPacket);
+        packets.add(createMetadataPacket());
+
+        return packets;
+    }
+
+    private ClientboundSetEntityDataPacket createMetadataPacket() {
+        List<SynchedEntityData.DataValue<?>> dataValues = new ArrayList<>();
+
+        dataValues.add(SynchedEntityData.DataValue.create(DATA_SHARED_FLAGS_ID, entityFlags));
+        dataValues.add(SynchedEntityData.DataValue.create(INTERPOLATION_START, interpolationDelay));
+        dataValues.add(SynchedEntityData.DataValue.create(INTERPOLATION_DURATION, interpolationDuration));
+        dataValues.add(SynchedEntityData.DataValue.create(POS_ROT_INTERPOLATION_DURATION, posRotInterpolationDuration));
+        dataValues.add(SynchedEntityData.DataValue.create(TRANSLATION, translation));
+        dataValues.add(SynchedEntityData.DataValue.create(SCALE, scale));
+        dataValues.add(SynchedEntityData.DataValue.create(LEFT_ROTATION, leftRotation));
+        dataValues.add(SynchedEntityData.DataValue.create(RIGHT_ROTATION, rightRotation));
+        dataValues.add(SynchedEntityData.DataValue.create(BILLBOARD, billboard));
+        dataValues.add(SynchedEntityData.DataValue.create(BRIGHTNESS, brightness));
+        dataValues.add(SynchedEntityData.DataValue.create(VIEW_RANGE, viewRange));
+        dataValues.add(SynchedEntityData.DataValue.create(SHADOW_RADIUS, shadowRadius));
+        dataValues.add(SynchedEntityData.DataValue.create(SHADOW_STRENGTH, shadowStrength));
+        dataValues.add(SynchedEntityData.DataValue.create(WIDTH, width));
+        dataValues.add(SynchedEntityData.DataValue.create(HEIGHT, height));
+        dataValues.add(SynchedEntityData.DataValue.create(GLOW_COLOR, glowColorOverride));
+
+        if (displayType == DisplayType.BLOCK_DISPLAY && blockState != null) {
+            dataValues.add(SynchedEntityData.DataValue.create(BLOCK_STATE_ACCESSOR, blockState));
+        } else if (displayType == DisplayType.ITEM_DISPLAY) {
+            if (nmsItemStack != null) {
+                dataValues.add(SynchedEntityData.DataValue.create(ITEM_STACK_ACCESSOR, nmsItemStack.copy()));
+            }
+            dataValues.add(SynchedEntityData.DataValue.create(ITEM_TRANSFORM, itemTransform));
+        }
+
+        return new ClientboundSetEntityDataPacket(entityId, dataValues);
+    }
+
+    /**
+     * Create teleport packet using the 1.21.2+ PositionMoveRotation format.
+     */
+    private ClientboundTeleportEntityPacket createTeleportPacket() {
+        PositionMoveRotation positionMoveRotation = new PositionMoveRotation(
+                new Vec3(location.getX(), location.getY(), location.getZ()),
+                Vec3.ZERO,
+                location.getYaw(),
+                location.getPitch()
+        );
+        return new ClientboundTeleportEntityPacket(
+                entityId,
+                positionMoveRotation,
+                Set.of(),
+                false
+        );
+    }
+
+    // ==================== CraftBukkit Reflection Helpers ====================
+    // Avoid compile-time CraftBukkit imports which get reobfuscated by paperweight
+    // to versioned packages that may not match the runtime server.
+
+    private static ServerPlayer getServerPlayer(Player player) {
+        try {
+            return (ServerPlayer) player.getClass().getMethod("getHandle").invoke(player);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get ServerPlayer handle", e);
+        }
+    }
+
+    private static BlockState toNmsBlockState(BlockData blockData) {
+        try {
+            return (BlockState) blockData.getClass().getMethod("getState").invoke(blockData);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert BlockData to NMS BlockState", e);
+        }
+    }
+
+    private static net.minecraft.world.item.ItemStack toNmsItemStack(ItemStack itemStack) {
+        try {
+            String cbPkg = Bukkit.getServer().getClass().getPackage().getName();
+            Class<?> cls = Class.forName(cbPkg + ".inventory.CraftItemStack");
+            return (net.minecraft.world.item.ItemStack) cls.getMethod("asNMSCopy", ItemStack.class).invoke(null, itemStack);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert ItemStack to NMS", e);
+        }
+    }
+}

--- a/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/NMSDialogCallbackBridgeImpl.java
+++ b/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/NMSDialogCallbackBridgeImpl.java
@@ -1,0 +1,219 @@
+package cn.lunadeer.dominion.v1_21_11.nms;
+
+import cn.lunadeer.dominion.nms.NMSDialogCallbackBridge;
+import cn.lunadeer.dominion.utils.XLogger;
+import cn.lunadeer.dominion.utils.dialogui.DialogCallbackRegistry;
+import cn.lunadeer.dominion.utils.dialogui.DialogPayload;
+import cn.lunadeer.dominion.utils.dialogui.DialogResponse;
+import cn.lunadeer.dominion.utils.scheduler.Scheduler;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.common.ServerboundCustomClickActionPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Minecraft 1.21.11 inbound packet bridge for vanilla custom-click actions.
+ */
+public final class NMSDialogCallbackBridgeImpl implements NMSDialogCallbackBridge {
+    private static final String HANDLER_NAME = "dominion_dialog_callback";
+    private static final int MAX_PAYLOAD_DEPTH = 16;
+    private static final int MAX_PAYLOAD_VALUES = 256;
+    private static final int MAX_KEY_LENGTH = 128;
+    private static final int MAX_STRING_LENGTH = 32_767;
+    private static final int MAX_LIST_LENGTH = 256;
+    private static final Field LISTENER_CONNECTION = field(ServerCommonPacketListenerImpl.class, "connection");
+    private static final Field CONNECTION_CHANNEL = field(Connection.class, "channel");
+    private final Map<UUID, Channel> channels = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean install(Player player) {
+        if (player == null || !player.isOnline()) return false;
+        try {
+            Channel channel = channel(player);
+            if (!channel.isOpen()) return false;
+            Runnable install = () -> {
+                if (channel.pipeline().get(HANDLER_NAME) == null) {
+                    channel.pipeline().addBefore("packet_handler", HANDLER_NAME, new InboundHandler(player));
+                }
+            };
+            runOnEventLoop(channel, install);
+            boolean installed = channel.pipeline().get(HANDLER_NAME) != null;
+            if (installed) channels.put(player.getUniqueId(), channel);
+            return installed;
+        } catch (Throwable throwable) {
+            XLogger.debug("Unable to install dialog callback bridge for {0}: {1}",
+                    player.getName(), throwable.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public void uninstall(Player player) {
+        if (player == null) return;
+        Channel channel = channels.remove(player.getUniqueId());
+        if (channel != null) remove(channel);
+        DialogCallbackRegistry.INSTANCE.invalidate(player.getUniqueId());
+    }
+
+    @Override
+    public boolean isInstalled(Player player) {
+        if (player == null) return false;
+        Channel channel = channels.get(player.getUniqueId());
+        return channel != null && channel.isOpen() && channel.pipeline().get(HANDLER_NAME) != null;
+    }
+
+    @Override
+    public void shutdown() {
+        channels.values().forEach(this::remove);
+        channels.clear();
+        DialogCallbackRegistry.INSTANCE.clear();
+    }
+
+    private void remove(Channel channel) {
+        try {
+            runOnEventLoop(channel, () -> {
+                if (channel.pipeline().get(HANDLER_NAME) != null) channel.pipeline().remove(HANDLER_NAME);
+            });
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static void runOnEventLoop(Channel channel, Runnable action) {
+        if (channel.eventLoop().inEventLoop()) {
+            action.run();
+        } else {
+            channel.eventLoop().submit(action).syncUninterruptibly();
+        }
+    }
+
+    private static Channel channel(Player player) throws ReflectiveOperationException {
+        ServerPlayer serverPlayer = (ServerPlayer) player.getClass().getMethod("getHandle").invoke(player);
+        Connection connection = (Connection) LISTENER_CONNECTION.get(serverPlayer.connection);
+        return (Channel) CONNECTION_CHANNEL.get(connection);
+    }
+
+    private static Field field(Class<?> owner, String name) {
+        try {
+            Field field = owner.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+
+    private final class InboundHandler extends ChannelDuplexHandler {
+        private final Player player;
+
+        private InboundHandler(Player player) {
+            this.player = player;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext context, Object message) throws Exception {
+            if (!(message instanceof ServerboundCustomClickActionPacket packet)
+                    || !DialogCallbackRegistry.CALLBACK_ACTION_ID.equals(packet.id().toString())) {
+                context.fireChannelRead(message);
+                return;
+            }
+
+            if (packet.payload().isEmpty() || !(packet.payload().get() instanceof CompoundTag compound)) return;
+            String token = compound.getString(DialogCallbackRegistry.TOKEN_KEY).orElse(null);
+            if (token == null) return;
+
+            DialogResponse response;
+            try {
+                response = new DialogResponse(decodePayload(compound));
+            } catch (IllegalArgumentException ignored) {
+                return;
+            }
+            DialogCallbackRegistry.Invocation invocation = DialogCallbackRegistry.INSTANCE.consume(
+                    player.getUniqueId(), token, response);
+            if (invocation == null) return;
+
+            Scheduler.runEntityTask(() -> {
+                if (!player.isOnline()) return;
+                try {
+                    invocation.execute(player);
+                } catch (Throwable throwable) {
+                    XLogger.error("Dialog callback failed for {0}: {1}", player.getName(), throwable.getMessage());
+                }
+            }, player);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext context) throws Exception {
+            channels.remove(player.getUniqueId(), context.channel());
+            DialogCallbackRegistry.INSTANCE.invalidate(player.getUniqueId());
+            context.fireChannelInactive();
+        }
+    }
+
+    private static DialogPayload payload(CompoundTag compound, DecodeBudget budget, int depth) {
+        if (depth > MAX_PAYLOAD_DEPTH) throw new IllegalArgumentException("Dialog payload is too deeply nested");
+        Map<String, DialogPayload.Value> values = new LinkedHashMap<>();
+        for (Map.Entry<String, Tag> entry : compound.entrySet()) {
+            if (entry.getKey().length() > MAX_KEY_LENGTH) {
+                throw new IllegalArgumentException("Dialog payload key is too long");
+            }
+            budget.take();
+            values.put(entry.getKey(), value(entry.getValue(), budget, depth + 1));
+        }
+        return new DialogPayload(values);
+    }
+
+    static DialogPayload decodePayload(CompoundTag compound) {
+        return payload(compound, new DecodeBudget(), 0);
+    }
+
+    private static DialogPayload.Value value(Tag tag, DecodeBudget budget, int depth) {
+        if (depth > MAX_PAYLOAD_DEPTH) throw new IllegalArgumentException("Dialog payload is too deeply nested");
+        return switch (tag.getId()) {
+            case Tag.TAG_STRING -> {
+                String value = tag.asString().orElse("");
+                if (value.length() > MAX_STRING_LENGTH) {
+                    throw new IllegalArgumentException("Dialog payload string is too long");
+                }
+                yield DialogPayload.string(value);
+            }
+            case Tag.TAG_BYTE -> DialogPayload.bool(tag.asBoolean().orElse(false));
+            case Tag.TAG_SHORT, Tag.TAG_INT, Tag.TAG_LONG -> DialogPayload.integer(tag.asLong().orElse(0L));
+            case Tag.TAG_FLOAT, Tag.TAG_DOUBLE -> DialogPayload.floating(tag.asDouble().orElse(0D));
+            case Tag.TAG_COMPOUND -> DialogPayload.compound(payload((CompoundTag) tag, budget, depth));
+            case Tag.TAG_LIST -> {
+                if (((ListTag) tag).size() > MAX_LIST_LENGTH) {
+                    throw new IllegalArgumentException("Dialog payload list is too long");
+                }
+                ArrayList<DialogPayload.Value> entries = new ArrayList<>();
+                for (Tag entry : (ListTag) tag) {
+                    budget.take();
+                    entries.add(value(entry, budget, depth + 1));
+                }
+                yield DialogPayload.list(entries);
+            }
+            default -> throw new IllegalArgumentException("Unsupported dialog payload tag " + tag.getId());
+        };
+    }
+
+    private static final class DecodeBudget {
+        private int remaining = MAX_PAYLOAD_VALUES;
+
+        private void take() {
+            if (--remaining < 0) throw new IllegalArgumentException("Dialog payload contains too many values");
+        }
+    }
+}

--- a/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/NMSDialogFactoryImpl.java
+++ b/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/NMSDialogFactoryImpl.java
@@ -1,4 +1,4 @@
-package cn.lunadeer.dominion.v1_21_9.nms;
+package cn.lunadeer.dominion.v1_21_11.nms;
 
 import cn.lunadeer.dominion.nms.NMSDialogFactory;
 import cn.lunadeer.dominion.utils.dialogui.DialogCallbackRegistry;
@@ -27,7 +27,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.protocol.common.ClientboundClearDialogPacket;
 import net.minecraft.network.protocol.common.ClientboundShowDialogPacket;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.dialog.ActionButton;
 import net.minecraft.server.dialog.CommonButtonData;
 import net.minecraft.server.dialog.CommonDialogData;
@@ -65,7 +65,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Minecraft 1.21.9 implementation of the version-independent dialog model.
+ * Minecraft 1.21.11 implementation of the version-independent dialog model.
  */
 public final class NMSDialogFactoryImpl implements NMSDialogFactory {
     private final EncoderRegistry encoders = new EncoderRegistry();
@@ -73,8 +73,7 @@ public final class NMSDialogFactoryImpl implements NMSDialogFactory {
     @Override
     public boolean isSupported() {
         String version = XVersionManager.getMinecraftVersion();
-        return version.startsWith("1.21.9")
-                || version.startsWith("1.21.10");
+        return version.startsWith("1.21.11");
     }
 
     @Override
@@ -317,7 +316,7 @@ public final class NMSDialogFactoryImpl implements NMSDialogFactory {
                     context.player().getUniqueId(), context.session(), callback.callback(), callback.options());
             CompoundTag additions = new CompoundTag();
             additions.putString(DialogCallbackRegistry.TOKEN_KEY, token);
-            return new CustomAll(ResourceLocation.parse(DialogCallbackRegistry.CALLBACK_ACTION_ID), Optional.of(additions));
+            return new CustomAll(Identifier.parse(DialogCallbackRegistry.CALLBACK_ACTION_ID), Optional.of(additions));
         }
 
         private Action customClick(DialogSpec.CustomClickAction action) {
@@ -466,8 +465,8 @@ public final class NMSDialogFactoryImpl implements NMSDialogFactory {
                 profile.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    private static ResourceLocation identifier(DialogKey key) {
-        return ResourceLocation.fromNamespaceAndPath(key.namespace(), key.value());
+    private static Identifier identifier(DialogKey key) {
+        return Identifier.fromNamespaceAndPath(key.namespace(), key.value());
     }
 
     private static CompoundTag compound(DialogPayload payload) {

--- a/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/NMSPacketSenderImpl.java
+++ b/versions/v1_21_11/src/main/java/cn/lunadeer/dominion/v1_21_11/nms/NMSPacketSenderImpl.java
@@ -1,0 +1,26 @@
+package cn.lunadeer.dominion.v1_21_11.nms;
+
+import cn.lunadeer.dominion.nms.NMSPacketSender;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.server.level.ServerPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * NMS packet sender implementation for Minecraft 1.21.11.
+ */
+public class NMSPacketSenderImpl implements NMSPacketSender {
+
+    @Override
+    public void sendPacket(Player player, Object packet) {
+        if (player == null || packet == null) return;
+        getServerPlayer(player).connection.send((Packet<?>) packet);
+    }
+
+    private static ServerPlayer getServerPlayer(Player player) {
+        try {
+            return (ServerPlayer) player.getClass().getMethod("getHandle").invoke(player);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get ServerPlayer handle", e);
+        }
+    }
+}

--- a/versions/v1_21_11/src/test/java/cn/lunadeer/dominion/v1_21_11/nms/NMSDialogFactoryImplTest.java
+++ b/versions/v1_21_11/src/test/java/cn/lunadeer/dominion/v1_21_11/nms/NMSDialogFactoryImplTest.java
@@ -1,0 +1,101 @@
+package cn.lunadeer.dominion.v1_21_11.nms;
+
+import cn.lunadeer.dominion.utils.dialogui.DialogSpec;
+import com.google.gson.JsonParser;
+import net.kyori.adventure.text.Component;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.bukkit.craftbukkit.CraftRegistry;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NMSDialogFactoryImplTest {
+
+    @BeforeAll
+    static void bootstrapMinecraftRegistries() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+        CraftRegistry.setMinecraftRegistry(net.minecraft.core.RegistryAccess.EMPTY);
+    }
+
+    @Test
+    void encodesPlayerHeadObjectWithStoredSkinTexture() throws Exception {
+        UUID playerId = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
+        String skinUrl = "https://textures.minecraft.net/texture/example";
+        DialogSpec.PlayerHeadIcon playerHead = new DialogSpec.PlayerHeadIcon(
+                playerId, "LunaDeer", skinUrl, false);
+        Method method = NMSDialogFactoryImpl.class.getDeclaredMethod(
+                "component", Component.class, String.class, DialogSpec.PlayerHeadIcon.class);
+        method.setAccessible(true);
+
+        net.minecraft.network.chat.Component parsed =
+                (net.minecraft.network.chat.Component) method.invoke(
+                        null, Component.text("LunaDeer"),
+                        "minecraft:items/item/armor_stand", playerHead);
+
+        net.minecraft.network.chat.contents.ObjectContents contents = findObjectContents(parsed);
+        net.minecraft.network.chat.contents.objects.PlayerSprite sprite =
+                (net.minecraft.network.chat.contents.objects.PlayerSprite) contents.contents();
+        com.mojang.authlib.GameProfile profile = sprite.player().partialProfile();
+        assertEquals(playerId, profile.id());
+        assertEquals("LunaDeer", profile.name());
+        assertFalse(sprite.hat());
+        String property = profile.properties().get("textures").iterator().next().value();
+        String decoded = new String(Base64.getDecoder().decode(property), StandardCharsets.UTF_8);
+        assertEquals(skinUrl, JsonParser.parseString(decoded).getAsJsonObject()
+                .getAsJsonObject("textures").getAsJsonObject("SKIN")
+                .get("url").getAsString());
+    }
+
+    @Test
+    void invalidPlayerNameFallsBackToBuiltInSteveSkin() throws Exception {
+        UUID playerId = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
+        DialogSpec.PlayerHeadIcon playerHead = new DialogSpec.PlayerHeadIcon(
+                playerId,
+                "Clincded_Xsa_79a4df70",
+                "https://textures.minecraft.net/texture/example");
+        Method method = NMSDialogFactoryImpl.class.getDeclaredMethod(
+                "component", Component.class, String.class, DialogSpec.PlayerHeadIcon.class);
+        method.setAccessible(true);
+
+        net.minecraft.network.chat.Component parsed =
+                (net.minecraft.network.chat.Component) method.invoke(
+                        null, Component.text("Clincded_Xsa_79a4df70"),
+                        "minecraft:items/item/armor_stand", playerHead);
+
+        net.minecraft.network.chat.contents.ObjectContents contents = findObjectContents(parsed);
+        net.minecraft.network.chat.contents.objects.PlayerSprite sprite =
+                (net.minecraft.network.chat.contents.objects.PlayerSprite) contents.contents();
+        com.mojang.authlib.GameProfile profile = sprite.player().partialProfile();
+        assertTrue(playerHead.usesDefaultSkin());
+        assertEquals(playerId, profile.id());
+        assertEquals(DialogSpec.PlayerHeadIcon.DEFAULT_PLAYER_NAME, profile.name());
+        assertTrue(profile.properties().isEmpty());
+        assertEquals(DialogSpec.PlayerHeadIcon.DEFAULT_SKIN_TEXTURE,
+                sprite.player().skinPatch().body().orElseThrow().id().toString());
+    }
+
+    private static net.minecraft.network.chat.contents.ObjectContents findObjectContents(
+            net.minecraft.network.chat.Component component) {
+        if (component.getContents() instanceof net.minecraft.network.chat.contents.ObjectContents object) {
+            return object;
+        }
+        for (net.minecraft.network.chat.Component sibling : component.getSiblings()) {
+            try {
+                return findObjectContents(sibling);
+            } catch (AssertionError ignored) {
+                // Continue searching the component tree.
+            }
+        }
+        throw new AssertionError("No player object component found");
+    }
+}


### PR DESCRIPTION
当前版本在 1.21.11 上使用 Dialog 功能时会报
```log
[19:08:32] [Server thread/WARN]: [Dominion] Entity task for Dominion v4.9.4-release generated an exception
java.lang.NoClassDefFoundError: org/bukkit/craftbukkit/v1_21_R6/util/CraftChatMessage
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl.component(NMSDialogFactoryImpl.java:397) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl.plainMessage(NMSDialogFactoryImpl.java:361) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl$EncoderRegistry.lambda$new$0(NMSDialogFactoryImpl.java:139) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl$EncoderRegistry.body(NMSDialogFactoryImpl.java:237) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl$EncoderRegistry.lambda$common$15(NMSDialogFactoryImpl.java:219) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214) ~[?:?]
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:5182) ~[?:?]
	at java.base/java.util.Collections$2.forEachRemaining(Collections.java:5190) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:635) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:291) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:652) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:658) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:663) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl$EncoderRegistry.common(NMSDialogFactoryImpl.java:219) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl$EncoderRegistry.multiAction(NMSDialogFactoryImpl.java:275) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl$EncoderRegistry.lambda$new$8(NMSDialogFactoryImpl.java:153) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl$EncoderRegistry.dialog(NMSDialogFactoryImpl.java:215) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.v1_21_9.nms.NMSDialogFactoryImpl.show(NMSDialogFactoryImpl.java:105) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.uis.dialog.DominionDialogUi.show(DominionDialogUi.java:215) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.uis.dialog.DominionDialogUi.render(DominionDialogUi.java:185) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.uis.dialog.DominionDialogUi.lambda$openMain$0(DominionDialogUi.java:78) ~[?:?]
	at [领地]Dominion-4.9.4-release-lite.jar//cn.lunadeer.dominion.utils.scheduler.Scheduler.lambda$runEntityTask$6(Scheduler.java:125) ~[?:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:167) ~[leaf-1.21.11.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:114) ~[leaf-1.21.11.jar:?]
	at io.papermc.paper.threadedregions.EntityScheduler.executeTick(EntityScheduler.java:235) ~[leaf-1.21.11.jar:1.21.11-174-3727fcc]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1890) ~[leaf-1.21.11.jar:1.21.11-174-3727fcc]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1714) ~[leaf-1.21.11.jar:1.21.11-174-3727fcc]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:492) ~[leaf-1.21.11.jar:1.21.11-174-3727fcc]
	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1771) ~[leaf-1.21.11.jar:1.21.11-174-3727fcc]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1435) ~[leaf-1.21.11.jar:1.21.11-174-3727fcc]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:430) ~[leaf-1.21.11.jar:1.21.11-174-3727fcc]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: java.lang.ClassNotFoundException: org.bukkit.craftbukkit.v1_21_R6.util.CraftChatMessage
	... 34 more
```
1.21.11 对应 Spigot 映射为 v1_21_R7，不与 1.21.9 兼容，本 PR 补充了针对 1.21.11 的 NMS 代码